### PR TITLE
Faster, faster!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path       = "src/lib.rs"
 default = []
 gfx_rs_renderer = []
 audio = []
+blit_perf = []
 
 [dependencies]
 time = "0.1.35"

--- a/examples/perftest/perftest.py
+++ b/examples/perftest/perftest.py
@@ -1,0 +1,84 @@
+px8 / python cartridge
+version 1
+__python__
+
+import time
+
+
+first_time = True
+
+
+def small_rect():
+    rect(64, 64, 74, 74)
+
+
+def small_rectfill():
+    rectfill(64, 64, 74, 74)
+
+
+def large_rect():
+    rect(0, 0, 127, 127)
+
+
+def large_rectfill():
+    rectfill(0, 0, 127, 127)
+
+
+def text():
+    px8_print("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 0, 64, 7)
+
+
+def line_test():
+    line(0, 0, 127, 127, 7)
+
+
+def circ_test():
+    circ(63, 63, 40, 7)
+
+
+def circfill_test():
+    circfill(63, 63, 40, 7)
+
+
+def perftest(name, f, iterations):
+    start = time.time()
+    for i in range(iterations):
+        f()
+    end = time.time()
+    elapsed_time = end - start
+    time_per_op = elapsed_time * 1000000 / iterations
+    print("%-20s%8d%20.3f%20.3f" %
+          (name, iterations, elapsed_time, time_per_op))
+
+
+tests = [
+    ("cls", cls, 1000000),
+    ("small_rect", small_rect, 1000000),
+    ("small_rectfill", small_rectfill, 1000000),
+    ("large_rect", large_rect, 100000),
+    ("large_rectfill", large_rectfill, 10000),
+    ("text", text, 100000),
+    ("line", line_test, 100000),
+    ("circ", circ_test, 100000),
+    ("circfill", circfill_test, 10000)
+]
+
+
+def _init():
+    pass
+
+
+def _update():
+    pass
+
+
+def _draw():
+    global first_time
+    if first_time:
+        cls()
+        print("%-20s%-20s%-20s%-20s" %
+              ("test", "iterations", "total_time(secs)", "time_per_op(us)"))
+
+        for name, func, iterations in tests:
+            perftest(name, func, iterations)
+            first_time = False

--- a/src/px8/mod.rs
+++ b/src/px8/mod.rs
@@ -37,7 +37,7 @@ include!(concat!(env!("OUT_DIR"), "/parameters.rs"));
 pub const SCREEN_PIXELS: usize = SCREEN_WIDTH * SCREEN_HEIGHT;
 pub const SCREEN_PIXELS_RGB: usize = SCREEN_PIXELS * 3;
 
-pub type ScreenBuffer = [u32; SCREEN_PIXELS];
+pub type ScreenBuffer = [u8; SCREEN_PIXELS];
 pub type ScreenBufferRGB = [u8; SCREEN_PIXELS_RGB];
 
 pub const SCREEN_EMPTY: ScreenBuffer = [0; SCREEN_PIXELS];

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -13,6 +13,8 @@ pub mod renderer {
     use sdl2::pixels::PixelFormatEnum;
     use std::sync::{Arc, Mutex};
     use num;
+    use time::PreciseTime;
+
 
     #[derive(Clone, Debug)]
     pub enum RendererError {
@@ -32,6 +34,7 @@ pub mod renderer {
         viewport_width: u32,
         viewport_height: u32,
         viewport_offset: Point,
+        frame: u32,
     }
 
     impl Renderer {
@@ -81,6 +84,7 @@ pub mod renderer {
                    viewport_width: 0,
                    viewport_height: 0,
                    viewport_offset: Point::new(0, 0),
+                   frame: 0,
                })
         }
 
@@ -88,13 +92,45 @@ pub mod renderer {
             if self.viewport_width == 0 {
                 self.update_dimensions();
             }
+
+            // Translate the pixel values to RGB colors.
+            let src_buffer = screen.lock().unwrap().back_buffer;
+            let mut rgb_buffer = *screen.lock().unwrap().buffer_rgb;
+            let mut palette = px8::PALETTE.lock().unwrap();
+
+            let mut j = 0;
+            let mut cached_pixel: u8 = 0;
+            let mut rgb = palette.get_rgb(cached_pixel as u32);
+
+            let start = PreciseTime::now();
+
+            for pixel in src_buffer.iter() {
+                if *pixel != cached_pixel {
+                    rgb = palette.get_rgb(*pixel as u32);
+                    cached_pixel = *pixel;
+                }
+                rgb_buffer[j] = rgb.b;
+                rgb_buffer[j + 1] = rgb.g;
+                rgb_buffer[j + 2] = rgb.r;
+                j = j + 3;
+            }
+
+            let t1 = PreciseTime::now();
+
+            // Update the texture with the RGB values.
             self.texture
-                .update(None,
-                        &mut *screen.lock().unwrap().buffer_rgb,
-                        px8::SCREEN_WIDTH * 3)
+                .update(None, &mut rgb_buffer, px8::SCREEN_WIDTH * 3)
                 .unwrap();
 
-            self.renderer.clear();
+            let t2 = PreciseTime::now();
+
+            // Copy the texture to the screen.
+            // Only need to clear the screen if there is any border -
+            // the main display area will be overwritten.
+            if self.viewport_offset.x() != 0 || self.viewport_offset.y() != 0 {
+                self.renderer.clear();
+            }
+
             self.renderer
                 .copy(&self.texture,
                       Some(Rect::new(0, 0, px8::SCREEN_WIDTH as u32, px8::SCREEN_HEIGHT as u32)),
@@ -103,7 +139,24 @@ pub mod renderer {
                                      self.viewport_width,
                                      self.viewport_height)))
                 .unwrap();
+
+            let t3 = PreciseTime::now();
+
             self.renderer.present();
+
+            let t4 = PreciseTime::now();
+
+            if cfg!(feature = "blit_perf") {
+                if self.frame % 60 == 0 {
+                    println!("gen_rgb:{} update_tex:{} copy_tex:{} present:{}",
+                             start.to(t1),
+                             t1.to(t2),
+                             t2.to(t3),
+                             t3.to(t4))
+                }
+            }
+
+            self.frame += 1;
         }
 
         pub fn update_dimensions(&mut self) {

--- a/src/sound/mod.rs
+++ b/src/sound/mod.rs
@@ -88,16 +88,16 @@ pub mod sound {
         type Channel = u8;
         /// Callback routine for SDL2
         fn callback(&mut self, out: &mut [u8]) {
-           if self.generator
-                  .get_samples(self.frame_size, &mut self.generator_buffer) > 0 {
-               let mut idx = 0;
-               for item in self.generator_buffer.iter().take(self.frame_size) {
-                   for _ in 0..(self.channel_count) {
-                       out[idx] = *item;
-                       idx += 1;
-                   }
-               }
-           }
+            if self.generator
+                   .get_samples(self.frame_size, &mut self.generator_buffer) > 0 {
+                let mut idx = 0;
+                for item in self.generator_buffer.iter().take(self.frame_size) {
+                    for _ in 0..(self.channel_count) {
+                        out[idx] = *item;
+                        idx += 1;
+                    }
+                }
+            }
         }
     }
 
@@ -198,9 +198,7 @@ pub mod sound {
             self.data_sender.send(data);
         }
 
-        pub fn stop(&mut self, _id: u32) {
-
-        }
+        pub fn stop(&mut self, _id: u32) {}
     }
 }
 
@@ -237,7 +235,10 @@ pub mod sound {
                    _buffer_size: usize,
                    _channel_count: u16)
                    -> SoundInterface<T> {
-            SoundInterface { phantom: PhantomData, data_sender: PhantomData }
+            SoundInterface {
+                phantom: PhantomData,
+                data_sender: PhantomData,
+            }
         }
 
         pub fn start(&mut self) {}


### PR DESCRIPTION
Performance improvements, focussing on putpixel performance.
Plus a few small bonus fixes.
- Change ScreenBuffer from u32 to u8 (assume maximum 8bpp).
- Moved screen buffer to RGB conversion to renderer.
- Only perform a single clipping operation during putpixel by combining screen bounds and clip rect.
- Change color_map and transparency_map to use 256 entry arrays rather than HashMaps.
- New implementations of hline(), rect(), rectfill().
- Added basic performance test: examples/perftest/perftest.py.
- Fixed a few bounds checks.
- Don't reset camera on (-1,-1), as this could be a valid request.
- Fixed clipping to discard pixels outside clipping rect, rather than inside!

Before/after performance results, showing 4x - 20x improvement :-)

```
[before]
test                iterations          total_time(secs)    time_per_op(us)
cls                  1000000               6.892               6.892
small_rect           1000000               3.588               3.588
small_rectfill       1000000               9.083               9.083
large_rect            100000               2.728              27.284
large_rectfill         10000               8.283             828.340
text                  100000               1.569              15.695
line                  100000               0.795               7.955
circ                  100000               1.398              13.979
circfill               10000               2.533             253.344

[after]
test                iterations          total_time(secs)    time_per_op(us)
cls                  1000000               0.518               0.518
small_rect           1000000               1.470               1.470
small_rectfill       1000000               1.645               1.645
large_rect            100000               0.256               2.561
large_rectfill         10000               0.397              39.729
text                  100000               0.381               3.812
line                  100000               0.179               1.791
circ                  100000               0.225               2.251
circfill               10000               0.139              13.866
```

I also added some detailed rendering performance measurements, as I added the new screen buffer to RGB translation there.  This showed the RGB conversion step (the first measurement below) to be minimal (about 50us per frame).
I left these measurements in the code - they can be enabled/displayed using a new "blit_perf" feature (disabled by default).

```
Render performance
gen_rgb:PT0.000063756S update_tex:PT0.000233939S copy_tex:PT0.003474850S present:PT0.002301755S
gen_rgb:PT0.000047360S update_tex:PT0.000262126S copy_tex:PT0.000026018S present:PT0.015566266S
gen_rgb:PT0.000048056S update_tex:PT0.000292806S copy_tex:PT0.000110042S present:PT0.014779848S
gen_rgb:PT0.000046136S update_tex:PT0.000260689S copy_tex:PT0.000025983S present:PT0.015485252S
```

I've tested with the demos and games, found and fixed a few issues.  Currently have no known issues with the changes.
