### PR TITLE
Clippy cleanup

### DIFF
--- a/examples/helloworld.rs
+++ b/examples/helloworld.rs
@@ -31,12 +31,12 @@ impl HelloWorld {
 
 impl RustPlugin for HelloWorld {
     fn init(&mut self, screen: Arc<Mutex<gfx::Screen>>) -> f64 {
-        match cartridge::Cartridge::parse(self.sprite_filename.clone(), false) {
+        match cartridge::Cartridge::parse(&self.sprite_filename, false) {
             Ok(c) => screen.lock().unwrap().set_sprites(c.gfx.sprites),
             Err(e) => panic!("Impossible to load the assets {:?}", e),
         }
 
-        return 0.;
+        0.0
     }
 
     fn update(&mut self, _players: Arc<Mutex<Players>>) -> f64 {
@@ -44,7 +44,7 @@ impl RustPlugin for HelloWorld {
 
         self.t += 1;
 
-        return 0.;
+        0.0
     }
 
     fn draw(&mut self, screen: Arc<Mutex<gfx::Screen>>) -> f64 {
@@ -70,8 +70,7 @@ impl RustPlugin for HelloWorld {
             }
         }
 
-
-        return 0.;
+        0.0
     }
 }
 
@@ -96,10 +95,11 @@ fn main() {
 
     let helloworld_example = HelloWorld::new("./examples/helloworld/helloworld.dpx8".to_string());
 
-    let mut frontend = match frontend::Frontend::init(px8::gfx::Scale::Scale4x, false, true) {
-        Err(error) => panic!("{:?}", error),
-        Ok(frontend) => frontend,
-    };
+    let mut frontend =
+        match frontend::Frontend::init(px8::gfx::Scale::Scale4x, false, true, true) {
+            Err(error) => panic!("{:?}", error),
+            Ok(frontend) => frontend,
+        };
 
     frontend.px8.register(helloworld_example);
     frontend.start("./sys/config/gamecontrollerdb.txt".to_string());

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -59,27 +59,22 @@ pub fn map_keycode(key: Keycode) -> (Option<PX8Key>, u8) {
         Keycode::Left => (Some(PX8Key::Left), 0),
         Keycode::Up => (Some(PX8Key::Up), 0),
         Keycode::Down => (Some(PX8Key::Down), 0),
-        Keycode::Z => (Some(PX8Key::O), 0),
-        Keycode::C => (Some(PX8Key::O), 0),
-        Keycode::N => (Some(PX8Key::O), 0),
-        Keycode::X => (Some(PX8Key::X), 0),
-        Keycode::V => (Some(PX8Key::X), 0),
-        Keycode::M => (Some(PX8Key::X), 0),
+
+        Keycode::Z | Keycode::C | Keycode::N => (Some(PX8Key::O), 0),
+        Keycode::X | Keycode::V | Keycode::M => (Some(PX8Key::X), 0),
 
         Keycode::F => (Some(PX8Key::Right), 1),
         Keycode::S => (Some(PX8Key::Left), 1),
         Keycode::E => (Some(PX8Key::Up), 1),
         Keycode::D => (Some(PX8Key::Down), 1),
 
-        Keycode::LShift => (Some(PX8Key::O), 1),
-        Keycode::Tab => (Some(PX8Key::O), 1),
+        Keycode::LShift | Keycode::Tab => (Some(PX8Key::O), 1),
 
-        Keycode::A => (Some(PX8Key::X), 1),
-        Keycode::Q => (Some(PX8Key::X), 1),
+        Keycode::A | Keycode::Q => (Some(PX8Key::X), 1),
 
         Keycode::P => (Some(PX8Key::Pause), 0),
-        Keycode::KpEnter => (Some(PX8Key::Enter), 0),
-        Keycode::Return => (Some(PX8Key::Enter), 0),
+
+        Keycode::KpEnter | Keycode::Return => (Some(PX8Key::Enter), 0),
 
         _ => (None, 0),
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -94,16 +94,12 @@ impl Players {
     }
 
     pub fn mouse_button_down(&mut self, mouse_btn: MouseButton, elapsed: f64) {
-        if mouse_btn == MouseButton::Left {
-            self.mouse.state = 1;
-        } else if mouse_btn == MouseButton::Right {
-            self.mouse.state = 2;
-        } else if mouse_btn == MouseButton::Middle {
-            self.mouse.state = 4;
-        } else {
-            self.mouse.state = 0;
-        }
-
+        self.mouse.state = match mouse_btn {
+            MouseButton::Left => 1,
+            MouseButton::Right => 2,
+            MouseButton::Middle => 4,
+            _ => 0,
+        };
         self.mouse.state_quick = self.mouse.state;
         self.mouse.delay = elapsed;
     }
@@ -138,7 +134,7 @@ impl Players {
         for (_, keys) in self.pkeys.iter_mut() {
             let ref mut current_keys = keys.keys;
 
-            let mut modif_quick:HashMap<PX8Key, bool> = HashMap::new();
+            let mut modif_quick: HashMap<PX8Key, bool> = HashMap::new();
 
             for (key_val, value) in current_keys.iter_mut() {
                 if *value {
@@ -164,10 +160,7 @@ impl Players {
     }
 
     pub fn key_down(&mut self, keycode: Keycode, repeat: bool, elapsed: f64) {
-        debug!("KEY {:?} {:?} {:?} -> DOWN",
-               keycode,
-               repeat,
-               elapsed);
+        debug!("KEY {:?} {:?} {:?} -> DOWN", keycode, repeat, elapsed);
 
         if self.akeys.contains_key(&keycode) {
             if !self.akeys[&keycode] {
@@ -184,10 +177,10 @@ impl Players {
 
     pub fn key_down_direct(&mut self, player: u8, key: PX8Key, repeat: bool, elapsed: f64) {
         debug!("KEY {:?} {:?} {:?} Player {:?} -> DOWN",
-        key,
-        repeat,
-        elapsed,
-        player);
+               key,
+               repeat,
+               elapsed,
+               player);
 
         match self.pkeys.get_mut(&player) {
             Some(keys) => {
@@ -276,7 +269,7 @@ impl Players {
                     2 if keys.keys_quick[&PX8Key::Up] => 1,
                     3 if keys.keys_quick[&PX8Key::Down] => 1,
                     4 if keys.keys_quick[&PX8Key::O] => 1,
-                    5 if keys.keys_quick[&PX8Key::X]=> 1,
+                    5 if keys.keys_quick[&PX8Key::X] => 1,
                     6 if keys.keys_quick[&PX8Key::Enter] => 1,
                     7 if keys.keys_quick[&PX8Key::Pause] => 1,
                     _ => 0,
@@ -298,10 +291,10 @@ impl Players {
                     Some(v) => {
                         return *v;
                     }
-                    None => ()
+                    None => (),
                 }
             }
-            None => ()
+            None => (),
         }
         false
     }
@@ -317,10 +310,10 @@ impl Players {
                     Some(v) => {
                         return *v;
                     }
-                    None => ()
+                    None => (),
                 }
             }
-            None => ()
+            None => (),
         }
         false
     }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -72,7 +72,11 @@ pub struct Frontend {
 }
 
 impl Frontend {
-    pub fn init(scale: Scale, fullscreen: bool, opengl: bool, show_mouse: bool) -> FrontendResult<Frontend> {
+    pub fn init(scale: Scale,
+                fullscreen: bool,
+                opengl: bool,
+                show_mouse: bool)
+                -> FrontendResult<Frontend> {
         info!("[Frontend] SDL2 init");
         let sdl_context = try!(sdl2::init());
 
@@ -204,9 +208,9 @@ impl Frontend {
         self.handle_event(false);
     }
 
-    pub fn run_cartridge(&mut self, filename: String, editor: bool, mode: px8::PX8Mode) {
+    pub fn run_cartridge(&mut self, filename: &str, editor: bool, mode: px8::PX8Mode) {
         let success = self.px8
-            .load_cartridge(filename.clone(),
+            .load_cartridge(filename,
                             self.info.clone(),
                             self.sound.clone(),
                             editor,
@@ -237,8 +241,16 @@ impl Frontend {
                 self.renderer
                     .window_coords_to_viewport_coords(mouse_state.x(), mouse_state.y());
 
-            self.px8.players.lock().unwrap().set_mouse_x(mouse_viewport_x);
-            self.px8.players.lock().unwrap().set_mouse_y(mouse_viewport_y);
+            self.px8
+                .players
+                .lock()
+                .unwrap()
+                .set_mouse_x(mouse_viewport_x);
+            self.px8
+                .players
+                .lock()
+                .unwrap()
+                .set_mouse_y(mouse_viewport_y);
 
             for event in self.event_pump.poll_iter() {
                 match event {
@@ -250,13 +262,15 @@ impl Frontend {
                         self.renderer.update_dimensions();
                     }
                     Event::MouseButtonDown { mouse_btn, .. } => {
-                        self.px8.players
+                        self.px8
+                            .players
                             .lock()
                             .unwrap()
                             .mouse_button_down(mouse_btn, self.elapsed_time);
                     }
                     Event::MouseButtonUp { mouse_btn, .. } => {
-                        self.px8.players
+                        self.px8
+                            .players
                             .lock()
                             .unwrap()
                             .mouse_button_up(mouse_btn, self.elapsed_time);
@@ -266,7 +280,8 @@ impl Frontend {
                         repeat,
                         ..
                     } => {
-                        self.px8.players
+                        self.px8
+                            .players
                             .lock()
                             .unwrap()
                             .key_down(keycode, repeat, self.elapsed_time);
@@ -276,15 +291,16 @@ impl Frontend {
                         } else if keycode == Keycode::F3 {
                             let dt = Local::now();
                             self.px8
-                                .screenshot("screenshot-".to_string() +
-                                            &dt.format("%Y-%m-%d-%H-%M-%S.png").to_string());
+                                .screenshot(&("screenshot-".to_string() +
+                                              &dt.format("%Y-%m-%d-%H-%M-%S.png").to_string()));
                         } else if keycode == Keycode::F4 {
                             let record_screen = self.px8.is_recording();
                             if !record_screen {
                                 let dt = Local::now();
                                 self.px8
-                                    .start_record("record-".to_string() +
-                                                  &dt.format("%Y-%m-%d-%H-%M-%S.gif").to_string());
+                                    .start_record(&("record-".to_string() +
+                                                    &dt.format("%Y-%m-%d-%H-%M-%S.gif")
+                                                         .to_string()));
                             } else {
                                 self.px8.stop_record(self.scale.factor());
                             }
@@ -314,7 +330,8 @@ impl Frontend {
                         }
 
                         if let Some(key) = map_button(button) {
-                            self.px8.players
+                            self.px8
+                                .players
                                 .lock()
                                 .unwrap()
                                 .key_down_direct(0, key, false, self.elapsed_time)
@@ -348,7 +365,8 @@ impl Frontend {
                                 self.px8.players.lock().unwrap().key_direc_ver_up(0);
                             } else {
                                 if state {
-                                    self.px8.players
+                                    self.px8
+                                        .players
                                         .lock()
                                         .unwrap()
                                         .key_down_direct(0, key, false, self.elapsed_time);
@@ -376,7 +394,8 @@ impl Frontend {
                                 self.px8.players.lock().unwrap().key_direc_ver_up(0);
                             } else {
                                 if state {
-                                    self.px8.players
+                                    self.px8
+                                        .players
                                         .lock()
                                         .unwrap()
                                         .key_down_direct(0, key, false, self.elapsed_time);
@@ -397,7 +416,8 @@ impl Frontend {
                         }
 
                         if let Some(key) = map_button_joystick(button_idx) {
-                            self.px8.players
+                            self.px8
+                                .players
                                 .lock()
                                 .unwrap()
                                 .key_down_direct(0, key, false, self.elapsed_time);
@@ -452,9 +472,21 @@ impl Frontend {
                 self.renderer
                     .window_coords_to_viewport_coords(mouse_state.x(), mouse_state.y());
 
-            self.px8.players.lock().unwrap().set_mouse_x(mouse_viewport_x);
-            self.px8.players.lock().unwrap().set_mouse_y(mouse_viewport_y);
-            self.px8.players.lock().unwrap().set_mouse_state(mouse_state);
+            self.px8
+                .players
+                .lock()
+                .unwrap()
+                .set_mouse_x(mouse_viewport_x);
+            self.px8
+                .players
+                .lock()
+                .unwrap()
+                .set_mouse_y(mouse_viewport_y);
+            self.px8
+                .players
+                .lock()
+                .unwrap()
+                .set_mouse_state(mouse_state);
 
             if mouse_state.left() {
                 debug!("MOUSE X {:?} Y {:?}",
@@ -476,7 +508,8 @@ impl Frontend {
                         repeat,
                         ..
                     } => {
-                        self.px8.players
+                        self.px8
+                            .players
                             .lock()
                             .unwrap()
                             .key_down(player, keycode, repeat, self.elapsed_time);
@@ -526,7 +559,8 @@ impl Frontend {
 
                         info!("ID [{:?}] Controller button Down {:?}", id, button);
                         if let Some(key) = map_button(button) {
-                            self.px8.players
+                            self.px8
+                                .players
                                 .lock()
                                 .unwrap()
                                 .key_down(0, key, false, self.elapsed_time)
@@ -569,7 +603,8 @@ impl Frontend {
                                 self.px8.players.lock().unwrap().key_direc_ver_up(0);
                             } else {
                                 if state {
-                                    self.px8.players
+                                    self.px8
+                                        .players
                                         .lock()
                                         .unwrap()
                                         .key_down(0, key, false, self.elapsed_time)
@@ -604,7 +639,8 @@ impl Frontend {
                                 self.px8.players.lock().unwrap().key_direc_ver_up(0);
                             } else {
                                 if state {
-                                    self.px8.players
+                                    self.px8
+                                        .players
                                         .lock()
                                         .unwrap()
                                         .key_down(0, key, false, self.elapsed_time)
@@ -626,7 +662,8 @@ impl Frontend {
 
                         info!("ID [{:?}] Joystick button DOWN {:?}", id, button_idx);
                         if let Some(key) = map_button_joystick(button_idx) {
-                            self.px8.players
+                            self.px8
+                                .players
                                 .lock()
                                 .unwrap()
                                 .key_down(0, key, false, self.elapsed_time)

--- a/src/gfx/mod.rs
+++ b/src/gfx/mod.rs
@@ -157,7 +157,7 @@ impl DynSprite {
                 r_mat[((n_cols - (i + 1)) + j * n_cols) as usize] = tmp;
             }
         }
-        return r_mat;
+        r_mat
     }
 
     pub fn flip_y(&mut self) -> DMatrixu32 {
@@ -174,7 +174,7 @@ impl DynSprite {
                 r_mat[(j + (n_rows - (i + 1)) * n_cols) as usize] = tmp;
             }
         }
-        return r_mat;
+        r_mat
     }
 }
 
@@ -211,7 +211,7 @@ impl Sprite {
         Sprite { data: v, flags: 0 }
     }
 
-    pub fn is_flags_set(&mut self, value: u8) -> bool {
+    pub fn is_flags_set(&self, value: u8) -> bool {
         let mut value = value << 1;
 
         if value == 0 {
@@ -221,12 +221,12 @@ impl Sprite {
         (self.flags & value) != 0
     }
 
-    pub fn is_bit_flags_set(&mut self, value: u8) -> bool {
+    pub fn is_bit_flags_set(&self, value: u8) -> bool {
         (self.flags & value) != 0
     }
 
 
-    pub fn get_flags(&mut self) -> u8 {
+    pub fn get_flags(&self) -> u8 {
         self.flags
     }
 
@@ -246,17 +246,17 @@ impl Sprite {
         self.data[idx] = col;
     }
 
-    pub fn get_data(&mut self) -> String {
+    pub fn get_data(&self) -> String {
         let mut data = String::new();
 
-        for c in self.data.clone() {
+        for c in &self.data {
             data.push_str(&format!("{:?}", c));
         }
 
-        return data;
+        data
     }
 
-    pub fn get_line(&mut self, line: u32) -> String {
+    pub fn get_line(&self, line: u32) -> String {
         let mut data = String::new();
 
         let mut data_clone = self.data.clone();
@@ -269,47 +269,42 @@ impl Sprite {
             data.push_str(&format!("{:x}", c));
         }
 
-        return data;
+        data
     }
 
-    pub fn horizontal_reflection(&mut self) -> [u8; 64] {
-        let mut ret: [u8; 64] = self.to_u8_64_array();
-
-
-        for i in 0..4 {
-            for j in 0..8 {
-                let tmp = ret[(i + j * 8) as usize];
-                ret[(i + j * 8) as usize] = ret[((8 - (i + 1)) + j * 8) as usize];
-                ret[((8 - (i + 1)) + j * 8) as usize] = tmp;
-            }
-        }
-
-        return ret;
-    }
-
-    pub fn vertical_reflection(&mut self) -> [u8; 64] {
+    pub fn horizontal_reflection(&self) -> [u8; 64] {
         let mut ret: [u8; 64] = self.to_u8_64_array();
 
         for i in 0..4 {
             for j in 0..8 {
-                let tmp = ret[(j + i * 8) as usize];
-                ret[(j + i * 8) as usize] = ret[(j + (8 - (i + 1)) * 8) as usize];
-                ret[(j + (8 - (i + 1)) * 8) as usize] = tmp;
+                ret.swap((i + j * 8) as usize, ((8 - (i + 1)) + j * 8) as usize);
             }
         }
 
-        return ret;
+        ret
     }
 
-    pub fn flip_x(&mut self) -> Sprite {
-        return Sprite::new(self.horizontal_reflection());
+    pub fn vertical_reflection(&self) -> [u8; 64] {
+        let mut ret: [u8; 64] = self.to_u8_64_array();
+
+        for i in 0..4 {
+            for j in 0..8 {
+                ret.swap((j + i * 8) as usize, (j + (8 - (i + 1)) * 8) as usize);
+            }
+        }
+
+        ret
     }
 
-    pub fn flip_y(&mut self) -> Sprite {
-        return Sprite::new(self.vertical_reflection());
+    pub fn flip_x(&self) -> Sprite {
+        Sprite::new(self.horizontal_reflection())
     }
 
-    pub fn to_u8_64_array(&mut self) -> [u8; 64] {
+    pub fn flip_y(&self) -> Sprite {
+        Sprite::new(self.vertical_reflection())
+    }
+
+    pub fn to_u8_64_array(&self) -> [u8; 64] {
         let mut arr = [0u8; 64];
         for (place, element) in arr.iter_mut().zip(self.data.iter()) {
             *place = *element;
@@ -530,7 +525,7 @@ impl Screen {
     }
 
     pub fn putpixel(&mut self, x: i32, y: i32, col: u32) {
-        return self.putpixel_(x, y, col);
+        self.putpixel_(x, y, col);
     }
 
     pub fn getpixel(&mut self, x: usize, y: usize) -> u32 {
@@ -541,12 +536,11 @@ impl Screen {
             return 0;
         }
 
-        return self.back_buffer[x + y * px8::SCREEN_WIDTH] as u32;
+        self.back_buffer[x + y * px8::SCREEN_WIDTH] as u32
     }
 
     pub fn pget(&mut self, x: u32, y: u32) -> u32 {
-        let col = self.getpixel(x as usize, y as usize);
-        return col;
+        self.getpixel(x as usize, y as usize)
     }
 
     pub fn pset(&mut self, x: i32, y: i32, col: i32) {
@@ -557,14 +551,14 @@ impl Screen {
     pub fn sget(&mut self, x: u32, y: u32) -> u8 {
         let idx_sprite = (x / 8) + 16 * (y / 8);
         let sprite = &self.sprites[idx_sprite as usize];
-        return *sprite.data.get(((x % 8) + (y % 8) * 8) as usize).unwrap();
+        sprite.data[((x % 8) + (y % 8) * 8) as usize]
     }
 
     pub fn sset(&mut self, x: u32, y: u32, col: i32) {
         let col = self._find_color(col);
 
         let idx_sprite = (x / 8) + 16 * (y / 8);
-        let ref mut sprite = self.sprites[idx_sprite as usize];
+        let sprite = &mut self.sprites[idx_sprite as usize];
         sprite.set_data(((x % 8) + (y % 8) * 8) as usize, col as u8);
     }
 
@@ -614,14 +608,13 @@ impl Screen {
 
         for k in 0..string.len() {
             let value = string.as_bytes()[k] as usize;
-            let data;
 
-            if value >= 32 && value <= 126 {
-                data = GLYPH[value - 32];
+            let data = if value >= 32 && value <= 126 {
+                GLYPH[value - 32]
             } else {
                 /* Unknown char, replace by a space */
-                data = [0x0000, 0x0000];
-            }
+                [0x0000, 0x0000]
+            };
 
             let mut idx = 1;
             let mut idx_1 = 0;
@@ -638,7 +631,7 @@ impl Screen {
                 idx_1 += 1;
 
                 if i % 8 == 7 {
-                    x = x + 1;
+                    x += 1;
                 }
                 if i == 15 {
                     idx = 0;
@@ -659,7 +652,7 @@ impl Screen {
         let dx = (x1 - x0).abs();
 
         let sx = if x0 < x1 { 1 } else { -1 };
-        let dy: i32 = -1 * (y1 - y0).abs();
+        let dy: i32 = -((y1 - y0).abs());
         let sy: i32 = if y0 < y1 { 1 } else { -1 };
         let mut err: i32 = dx + dy; /* error value e_xy */
 
@@ -835,8 +828,8 @@ impl Screen {
                     oj = j;
                 }
 
-                ix = ix + iy / rx;
-                iy = iy - ix / rx;
+                ix += iy / rx;
+                iy -= ix / rx;
             }
         } else {
             ix = 0;
@@ -884,8 +877,8 @@ impl Screen {
                     oh = h;
                 }
 
-                ix = ix + iy / ry;
-                iy = iy - ix / ry;
+                ix += iy / ry;
+                iy -= ix / ry;
             }
         }
     }
@@ -956,8 +949,8 @@ impl Screen {
                     oj = j;
                 }
 
-                ix = ix + iy / rx;
-                iy = iy - ix / rx;
+                ix += iy / rx;
+                iy -= ix / rx;
             }
         } else {
             ix = 0;
@@ -995,8 +988,8 @@ impl Screen {
                     oh = h;
                 }
 
-                ix = ix + iy / ry;
-                iy = iy - ix / ry;
+                ix += iy / ry;
+                iy -= ix / ry;
             }
         }
     }
@@ -1033,11 +1026,7 @@ impl Screen {
             idx += 1;
         }
 
-        self.line(*vx.get(idx).unwrap(),
-                  *vy.get(idx).unwrap(),
-                  *vx.get(0).unwrap(),
-                  *vy.get(0).unwrap(),
-                  col);
+        self.line(vx[idx], vy[idx], vx[0], vy[0], col);
     }
 
     pub fn spr(&mut self, n: u32, x: i32, y: i32, w: u32, h: u32, flip_x: bool, flip_y: bool) {
@@ -1084,13 +1073,13 @@ impl Screen {
                         self.putpixel_(new_x, new_y, *c as u32);
                     }
 
-                    index = index + 1;
+                    index += 1;
 
                     if index != 0 && index % 8 == 0 {
-                        new_y = new_y + 1;
+                        new_y += 1;
                         new_x = orig_x;
                     } else {
-                        new_x = new_x + 1;
+                        new_x += 1;
                     }
                 }
 
@@ -1138,9 +1127,9 @@ impl Screen {
         let mut v: Vec<u32> = Vec::new();
 
         while idx < data.len() {
-            let r = *data.get(idx).unwrap();
-            let g = *data.get(idx + 1).unwrap();
-            let b = *data.get(idx + 2).unwrap();
+            let r = data[idx];
+            let g = data[idx + 1];
+            let b = data[idx + 2];
 
             v.push(px8::PALETTE.lock().unwrap().add_color(r, g, b));
 
@@ -1202,7 +1191,7 @@ impl Screen {
 
                 // Skip the sprite 0
                 if idx_sprite != 0 {
-                    let mut sprite = self.sprites[idx_sprite as usize].clone();
+                    let sprite = self.sprites[idx_sprite as usize].clone();
                     debug!("GET SPRITE {:?}, {:?} {:?}", idx_sprite, map_x, map_y);
 
                     // not the correct layer
@@ -1214,13 +1203,13 @@ impl Screen {
                                 self.putpixel_(new_x, new_y, *c as u32);
                             }
 
-                            index = index + 1;
+                            index += 1;
 
                             if index > 0 && index % 8 == 0 {
-                                new_y = new_y + 1;
+                                new_y += 1;
                                 new_x = orig_x;
                             } else {
-                                new_x = new_x + 1;
+                                new_x += 1;
                             }
                         }
                     }
@@ -1244,9 +1233,7 @@ impl Screen {
             return 0;
         }
 
-        let value = self.map[x as usize][y as usize];
-
-        return value;
+        self.map[x as usize][y as usize]
     }
 
     pub fn mset(&mut self, x: i32, y: i32, v: u32) {
@@ -1325,8 +1312,7 @@ impl Screen {
             for j in 0..w2 {
                 x2 = (j * x_ratio) >> 16;
                 y2 = (i * y_ratio) >> 16;
-                ret.insert((i * w2 + j) as usize,
-                           *v.get((y2 * w1 + x2) as usize).unwrap());
+                ret.insert((i * w2 + j) as usize, v[(y2 * w1 + x2) as usize]);
             }
         }
 
@@ -1335,9 +1321,7 @@ impl Screen {
         if flip_x {
             for i in 0..w2 / 2 {
                 for j in 0..h2 {
-                    let tmp = ret[(i + j * w2) as usize];
-                    ret[(i + j * w2) as usize] = ret[((w2 - (i + 1)) + j * w2) as usize];
-                    ret[((w2 - (i + 1)) + j * w2) as usize] = tmp;
+                    ret.swap((i + j * w2) as usize, ((w2 - (i + 1)) + j * w2) as usize);
                 }
             }
         }
@@ -1345,9 +1329,7 @@ impl Screen {
         if flip_y {
             for i in 0..h2 / 2 {
                 for j in 0..w2 {
-                    let tmp = ret[(j + i * w2) as usize];
-                    ret[(j + i * w2) as usize] = ret[(j + (h2 - (i + 1)) * w2) as usize];
-                    ret[(j + (h2 - (i + 1)) * w2) as usize] = tmp;
+                    ret.swap((j + i * w2) as usize, (j + (h2 - (i + 1)) * w2) as usize);
                 }
             }
         }
@@ -1355,7 +1337,7 @@ impl Screen {
         let mut idx = 0;
         for j in 0..h2 {
             for i in 0..w2 {
-                let d: u8 = *ret.get(idx).unwrap();
+                let d: u8 = ret[idx];
                 idx += 1;
                 if d != 0 {
                     if !self.is_transparent(d as u32) {
@@ -1366,7 +1348,7 @@ impl Screen {
         }
     }
 
-    pub fn is_transparent(&mut self, value: u32) -> bool {
+    pub fn is_transparent(&self, value: u32) -> bool {
         if value <= 255 {
             self.transparency_map[value as usize]
         } else {
@@ -1385,10 +1367,8 @@ impl Screen {
     pub fn palt(&mut self, c: i32, t: bool) {
         if c == -1 {
             self._reset_transparency();
-        } else {
-            if (c >= 0) && (c <= 255) {
-                self.transparency_map[c as usize] = t;
-            }
+        } else if (c >= 0) && (c <= 255) {
+            self.transparency_map[c as usize] = t;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ mod sound;
 use gfx::Scale;
 use cartridge::Cartridge;
 
-fn print_usage(program: &str, opts: Options) {
+fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} FILE [options]", program);
     print!("{}", opts.usage(&brief));
 }
@@ -106,14 +106,14 @@ fn main() {
         Err(f) => panic!(f.to_string()),
     };
     if matches.opt_present("h") {
-        print_usage(&program, opts);
+        print_usage(&program, &opts);
         return;
     }
 
     let input = if !matches.free.is_empty() {
         matches.free[0].clone()
     } else {
-        print_usage(&program, opts);
+        print_usage(&program, &opts);
         return;
     };
 
@@ -139,30 +139,30 @@ fn main() {
 
     if matches.opt_present("c") {
         if input.contains(".png") {
-            match Cartridge::from_png_file(input) {
+            match Cartridge::from_png_file(&input) {
                 Ok(mut c) => {
                     println!("{:?}", c);
 
                     if matches.opt_present("d") {
-                        c.dump(matches.opt_str("d").unwrap());
+                        c.dump(&matches.opt_str("d").unwrap());
                     }
                 }
                 Err(e) => panic!(e),
             }
         } else if input.contains(".p8") {
-            match Cartridge::from_p8_file(input) {
+            match Cartridge::from_p8_file(&input) {
                 Ok(mut c) => {
                     println!("{:?}", c);
 
                     if matches.opt_present("d") {
                         c.set_mode(mode == px8::PX8Mode::PICO8);
-                        c.dump(matches.opt_str("d").unwrap());
+                        c.dump(&matches.opt_str("d").unwrap());
                     }
                 }
                 Err(e) => panic!(e),
             }
         } else if input.contains(".px8") {
-            match Cartridge::from_px8_file(input) {
+            match Cartridge::from_px8_file(&input) {
                 Ok(c) => {
                     println!("{:?}", c);
                 }
@@ -171,11 +171,11 @@ fn main() {
         }
     } else if matches.opt_present("t") {
         if input.contains(".png") {
-            match Cartridge::from_png_file(input) {
+            match Cartridge::from_png_file(&input) {
                 Ok(mut c) => {
                     println!("{:?}", c);
 
-                    c.save_in_p8(matches.opt_str("t").unwrap());
+                    c.save_in_p8(&matches.opt_str("t").unwrap());
                 }
                 Err(e) => panic!(e),
             }
@@ -185,7 +185,6 @@ fn main() {
         if matches.opt_present("s") {
             let value = matches.opt_str("s").unwrap().parse::<i32>().unwrap();
             match value {
-                1 => scale = Scale::Scale1x,
                 2 => scale = Scale::Scale2x,
                 3 => scale = Scale::Scale3x,
                 4 => scale = Scale::Scale4x,
@@ -197,20 +196,13 @@ fn main() {
             }
         }
 
-        let mut fullscreen = false;
-        if matches.opt_present("f") {
-            fullscreen = true;
-        }
-
-        let mut opengl = false;
-        if matches.opt_present("o") {
-            opengl = true;
-        }
+        let fullscreen = matches.opt_present("f");
+        let opengl = matches.opt_present("o");
 
         start_px8(scale,
                   fullscreen,
                   opengl,
-                  input,
+                  &input,
                   matches.opt_present("e"),
                   mode);
     }
@@ -219,7 +211,7 @@ fn main() {
 pub fn start_px8(scale: gfx::Scale,
                  fullscreen: bool,
                  opengl: bool,
-                 filename: String,
+                 filename: &str,
                  editor: bool,
                  mode: px8::PX8Mode) {
     let mut frontend = match frontend::Frontend::init(scale, fullscreen, opengl, false) {

--- a/src/plugins/python_plugin.rs
+++ b/src/plugins/python_plugin.rs
@@ -49,7 +49,7 @@ pub mod plugin {
     }
 
     def switch_palette(&self, name: String) -> PyResult<i32> {
-        self.palettes(py).lock().unwrap().switch_to(name);
+        self.palettes(py).lock().unwrap().switch_to(&name);
         Ok(0)
     }
 
@@ -598,10 +598,10 @@ pub mod plugin {
         }
         pub fn init(&mut self) {}
         pub fn draw(&mut self) -> bool {
-            return false;
+            false
         }
         pub fn update(&mut self) -> bool {
-            return false;
+            false
         }
         pub fn load_code(&mut self, data: String) -> bool {
             false

--- a/src/px8/mod.rs
+++ b/src/px8/mod.rs
@@ -544,10 +544,20 @@ impl Px8New {
             record: Record::new(),
             draw_return: true,
             update_return: true,
-            mouse_spr: vec![0, 1, 0, 0, 0, 0, 0, 0, 1, 7, 1, 0, 0, 0, 0, 0, 1, 7, 7, 1, 0, 0, 0,
-                            0, 1, 7, 7, 7, 1, 0, 0, 0, 1, 7, 7, 7, 7, 1, 0, 0, 1, 7, 7, 1, 1, 0,
-                            0, 0, 0, 1, 1, 7, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            mouse_spr: Px8New::mouse_sprite(),
         }
+    }
+
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    pub fn mouse_sprite() -> Vec<u8> {
+        vec![0, 1, 0, 0, 0, 0, 0, 0,
+             1, 7, 1, 0, 0, 0, 0, 0,
+             1, 7, 7, 1, 0, 0, 0, 0,
+             1, 7, 7, 7, 1, 0, 0, 0,
+             1, 7, 7, 7, 7, 1, 0, 0,
+             1, 7, 7, 1, 1, 0, 0, 0,
+             0, 1, 1, 7, 1, 0, 0, 0,
+             0, 0, 0, 0, 0, 0, 0, 0]
     }
 
     pub fn init(&mut self) {


### PR DESCRIPTION
Make code more Rust-tastic!  Mostly by following suggestions from Rust Clippy linting tool:
    https://github.com/Manishearth/rust-clippy

Clippy requires the nightly Rust build, so I run it as:
`cargo +nightly clippy`

Key changes:
- Remove quite a few unnecessary clone() calls
- Change `&mut self` to `&self` where possible
- Remove unnecessary return statements
- Pass immutable string parameters as `&str` rather than `String`
- Pass immutable Vector parameters as slices: `[String]` rather than `&Vector<String>`
- Simplify vector element access from `*data.get(idx).unwrap()` to  `data[idx]`

Note that there are still plenty more Clippy suggestions.  I'll save those for another day...